### PR TITLE
Fixes #8 -- Git Bash issues due to non-tty output

### DIFF
--- a/bin/dw-utils.js
+++ b/bin/dw-utils.js
@@ -53,6 +53,10 @@ function arg(){
 if (cli.command == 'init'){
   prompt.init(opts).then((config) => {
     fs.writeFileSync(path.join(root, 'dw.json'), JSON.stringify(config, null, 2))
+    if (!process.stdin.isTTY){
+      console.log('Config saved, press any key to continue');
+      process.exit();
+    }
   })
 } else {
 

--- a/helpers/format.js
+++ b/helpers/format.js
@@ -7,7 +7,6 @@ function sep(name){
   return chalk.red(
     center('<','=', (`[ ${chalk.gray.underline(name)} ]`), '>') + '\n'
   )
-  //return chalk.red('<' + '='.repeat(process.stdout.columns - 2) + '>\n')
 }
 
 function firstline(line){
@@ -26,7 +25,7 @@ var stateRegexes = {
 
 function center(start, fill, title, end){
   let titleLength = chalk.stripColor(title).length;
-  let width = process.stdout.columns;
+  let width = process.stdout.isTTY? process.stdout.columns : 80;
   let leftFill = (width - titleLength)/2 - chalk.stripColor(start).length;
   let rightFill = Math.ceil((width - titleLength)/2) - chalk.stripColor(end).length;
   return `${start}${fill.repeat(leftFill)}${title}${fill.repeat(rightFill)}${end}`;

--- a/watch.js
+++ b/watch.js
@@ -284,7 +284,7 @@ function squeeze(value){
   // Fit input to console;
   let style = chalkStyle(value);
   let width = process.stdout.columns;
-  if (width && width > 0 && width < length(value)){
+  if (process.stdout.isTTY && width && width > 0 && width < length(value)){
     // do the squeezing
     for (let i = 0; length(value) > width && i < lowPriority.length; i++){
       let r = lowPriority[i];


### PR DESCRIPTION
Makes it possible to `init` on GitBash, although the password will be in the clear.
Makes separators in `log` show up as expected.
disables truncation in `watch` for non TTY outputs.
