### PR TITLE
Follow symlinks

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -14,6 +14,7 @@ function zip(cartridges, metadataPath, outfile){
 
     //glob(cartridges + '/**/*(static|scripts|templates|forms|pipelines)/**', {
     glob(cartridges + '/**', {
+      follow: true,
       nosort: true,
       nodir: true
     },


### PR DESCRIPTION
Updated the `glob` call to follow symlinks -- our build process uses dw-utils and stitches together serveral submodules into a staging `cartridges` directory. Without this, `dw-utils` doesn't see any of those files when creating its zip file.