### PR TITLE
Adds error feedback when users cartridges config returns zero matches

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -23,6 +23,10 @@ function zip(cartridges, metadataPath, outfile){
         reject(err)
         return
       }
+      if (matches.length === 0){
+        reject('No matches for cartridges provided in dw.json')
+        return
+      }
       for (var i = 0; i < matches.length; i++){
         var file = matches[i]
         //var compress = !/\.(png|gif|jpg|jpeg)$/.test(file)


### PR DESCRIPTION
Previously, if the path provided for cartridges in dw.json had no matches (likely due to invalid path entered) then the user would see the operation "succeed" very quickly.