### PR TITLE
Updates readme to appropriately represent stability flag

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ The following flags are recognized
 | -C, --cartridges | Path to Cartridges from project root (Default is 'cartridges')       |
 | --save           | Save settings for future use                                         |
 | -a --activate    | Activates the version after a `clean` or an `upload-version`         |
-| -S, --stability  | Length of time the file's size should stay the same before uploading |
+| -s, --stability  | Length of time the file's size should stay the same before uploading |
 | -f, --follow     | Display only new changes for `log` compare to `tail -f`              |
 | -p, --prompt     | Prompt for password                                                  |
 | -h, --help       | Display help and usage details                                       |


### PR DESCRIPTION
Seemingly pedantic as it's just a casing issue, but it can create confusion for users.

Alternatively, the flag could be updated to match documentation in the cli.parse() block of bin/dw-utils.js but this would disrupt any users who are currently using the flag correctly (and I'm partial to lowercase flags unless uppercase is needed to express a force or modifier)